### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/ESAdjustableLabel/Readme.md
+++ b/ESAdjustableLabel/Readme.md
@@ -1,5 +1,5 @@
 
-#ESAdjustable Label Category
+# ESAdjustable Label Category
 
 Adjusting the size of a UILabel is a pain in the back. This category provides a couple of simple methods to make this process less painful:
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,5 @@
 
-#ESAdjustable Label Category
+# ESAdjustable Label Category
 
 Adjusting the size of a UILabel is a pain in the back. This category provides a couple of simple methods to make this process less painful:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
